### PR TITLE
Change options of eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
         "indent": ["error", 4],
         "strict": ["error", "global"],
         "no-cond-assign": ["error", "always"],
-        "linebreak-style": ["error", "unix"],
+        "linebreak-style": "off",
         "array-callback-return": "error",
         "block-scoped-var": "error",
         "complexity": "error",


### PR DESCRIPTION
Line break style can be a problem with developers of Windows when the IDE/editor use Windows style line break
